### PR TITLE
Add Organization ID to Attachments and Custom Fields

### DIFF
--- a/tap_trello.py
+++ b/tap_trello.py
@@ -46,6 +46,9 @@ trello_card_custom_fields_schema = {
         'idBoard': {
             'type': 'string'
         },
+        'idOrganization': {
+            'type': 'string'
+        },
         'name': {
             'type': 'string'
         },
@@ -67,6 +70,9 @@ trello_card_attachments_schema = {
             'type': 'string'
         },
         'idBoard': {
+            'type': 'string'
+        },
+        'idOrganization': {
             'type': 'string'
         },
         'idMember': {
@@ -138,6 +144,7 @@ try:
                             'id': attachment["id"],
                             'idCard': card["id"],
                             'idBoard': board["id"],
+                            'idOrganization': org["id"],
                             'idMember': attachment["idMember"],
                             'name': attachment["name"],
                             'url': attachment["url"],
@@ -169,6 +176,7 @@ try:
                                     'id': custom_field_item["id"],
                                     'idCard': card["id"],
                                     'idBoard': board["id"],
+                                    'idOrganization': org["id"],
                                     'name': field["name"],
                                     'value': custom_field_item["value"]["text"]
                                 }])
@@ -179,6 +187,7 @@ try:
                                     'id': custom_field_item["idCustomField"],
                                     'idCard': card["id"],
                                     'idBoard': board["id"],
+                                    'idOrganization': org["id"],
                                     'name': field["name"],
                                     'value':
                                     custom_field_item["value"]["number"]
@@ -193,6 +202,7 @@ try:
                                         custom_field_item["idCustomField"],
                                         'idCard': card["id"],
                                         'idBoard': board["id"],
+                                        'idOrganization': org["id"],
                                         'name': field["name"],
                                         'value': option["value"]["text"]
                                     }])


### PR DESCRIPTION
## what
* Add `idOrganization` to attachments and custom fields

## why
* We use Metabase for our analytics. The Metabase query builder tool doesn't support joining across multiple tables, so it's easier to just add the necessary fields.
* Writing the raw SQL defeats the ease of use of Metabase